### PR TITLE
Update images digests

### DIFF
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest@sha256:249a806fb678cb7325406516f2880a5e1425c85ba5b47eca17a9335c687f13da as builder
+FROM cgr.dev/chainguard/python:latest@sha256:7104953a948fcdfcc1305a4140d65e3be95846b109f1fee9c4f8988e215632bc as builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
Update images digests

```release-note
NONE
```


## Changes
<details>

```diff
diff --git a/distroless/Dockerfile b/distroless/Dockerfile
index 924e362..0ee752b 100644
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest@sha256:249a806fb678cb7325406516f2880a5e1425c85ba5b47eca17a9335c687f13da as builder
+FROM cgr.dev/chainguard/python:latest@sha256:7104953a948fcdfcc1305a4140d65e3be95846b109f1fee9c4f8988e215632bc as builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
```

</details>