### PR TITLE
Update images digests

### DIFF
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest@sha256:5050e88595e02879be85d0c1f9f8f3ffc743d8fe925d9b4c501df95e682ec5d1 as builder
+FROM cgr.dev/chainguard/python:latest@sha256:18974e90873baf1217c62e0daeed36ea873fb577193f7ce4814c051e78c68c03 as builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -12,7 +12,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-FROM cgr.dev/chainguard/python:latest@sha256:5050e88595e02879be85d0c1f9f8f3ffc743d8fe925d9b4c501df95e682ec5d1
+FROM cgr.dev/chainguard/python:latest@sha256:18974e90873baf1217c62e0daeed36ea873fb577193f7ce4814c051e78c68c03
 
 WORKDIR /linky
 

--- a/error_nonroot/Dockerfile
+++ b/error_nonroot/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
+FROM ubuntu:latest@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b
 RUN apt-get update && apt-get install -y nginx
 USER root
 CMD ["nginx", "-g", "daemon off;"]

--- a/traditional/Dockerfile
+++ b/traditional/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
+FROM ubuntu:24.04@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b
 
 RUN apt-get update && apt-get install nginx -y && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Update images digests

```release-note
NONE
```


## Changes
<details>

```diff
diff --git a/distroless/Dockerfile b/distroless/Dockerfile
index 872ea0e..d0ceec0 100644
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest@sha256:5050e88595e02879be85d0c1f9f8f3ffc743d8fe925d9b4c501df95e682ec5d1 as builder
+FROM cgr.dev/chainguard/python:latest@sha256:18974e90873baf1217c62e0daeed36ea873fb577193f7ce4814c051e78c68c03 as builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -12,7 +12,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-FROM cgr.dev/chainguard/python:latest@sha256:5050e88595e02879be85d0c1f9f8f3ffc743d8fe925d9b4c501df95e682ec5d1
+FROM cgr.dev/chainguard/python:latest@sha256:18974e90873baf1217c62e0daeed36ea873fb577193f7ce4814c051e78c68c03
 
 WORKDIR /linky
 
diff --git a/error_nonroot/Dockerfile b/error_nonroot/Dockerfile
index 7e13d6f..17a4ba2 100644
--- a/error_nonroot/Dockerfile
+++ b/error_nonroot/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
+FROM ubuntu:latest@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b
 RUN apt-get update && apt-get install -y nginx
 USER root
 CMD ["nginx", "-g", "daemon off;"]
diff --git a/traditional/Dockerfile b/traditional/Dockerfile
index 7683578..b07ade2 100644
--- a/traditional/Dockerfile
+++ b/traditional/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM ubuntu:24.04@sha256:186072bba1b2f436cbb91ef2567abca677337cfc786c86e107d25b7072feef0c
+FROM ubuntu:24.04@sha256:84e77dee7d1bc93fb029a45e3c6cb9d8aa4831ccfcc7103d36e876938d28895b
 
 RUN apt-get update && apt-get install nginx -y && rm -rf /var/lib/apt/lists/*
 
```

</details>