### PR TITLE
Update images digests

### DIFF
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest@sha256:bd849aeb63c12208ea68faa568c3874737cdc4d3742619d27e33bfb980c5772c as builder
+FROM cgr.dev/chainguard/python:latest@sha256:7b27b4bfa2836f4c7007238658754d94a06ba84461a7720f2e07e284c6e564a1 as builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -12,7 +12,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-FROM cgr.dev/chainguard/python:latest@sha256:bd849aeb63c12208ea68faa568c3874737cdc4d3742619d27e33bfb980c5772c
+FROM cgr.dev/chainguard/python:latest@sha256:7b27b4bfa2836f4c7007238658754d94a06ba84461a7720f2e07e284c6e564a1
 
 WORKDIR /linky
 

--- a/error_nonroot/Dockerfile
+++ b/error_nonroot/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+FROM ubuntu:latest@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64
 RUN apt-get update && apt-get install -y nginx
 USER root
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Update images digests

```release-note
NONE
```


## Changes
<details>

```diff
diff --git a/distroless/Dockerfile b/distroless/Dockerfile
index 69d4f00..46f024e 100644
--- a/distroless/Dockerfile
+++ b/distroless/Dockerfile
@@ -1,4 +1,4 @@
-FROM cgr.dev/chainguard/python:latest@sha256:bd849aeb63c12208ea68faa568c3874737cdc4d3742619d27e33bfb980c5772c as builder
+FROM cgr.dev/chainguard/python:latest@sha256:7b27b4bfa2836f4c7007238658754d94a06ba84461a7720f2e07e284c6e564a1 as builder
 
 ENV LANG=C.UTF-8
 ENV PYTHONDONTWRITEBYTECODE=1
@@ -12,7 +12,7 @@ COPY requirements.txt .
 
 RUN pip install --no-cache-dir -r requirements.txt
 
-FROM cgr.dev/chainguard/python:latest@sha256:bd849aeb63c12208ea68faa568c3874737cdc4d3742619d27e33bfb980c5772c
+FROM cgr.dev/chainguard/python:latest@sha256:7b27b4bfa2836f4c7007238658754d94a06ba84461a7720f2e07e284c6e564a1
 
 WORKDIR /linky
 
diff --git a/error_nonroot/Dockerfile b/error_nonroot/Dockerfile
index c1948b2..e2912f3 100644
--- a/error_nonroot/Dockerfile
+++ b/error_nonroot/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest@sha256:c4a8d5503dfb2a3eb8ab5f807da5bc69a85730fb49b5cfca2330194ebcc41c7b
+FROM ubuntu:latest@sha256:f3d28607ddd78734bb7f71f117f3c6706c666b8b76cbff7c9ff6e5718d46ff64
 RUN apt-get update && apt-get install -y nginx
 USER root
 CMD ["nginx", "-g", "daemon off;"]
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas da Release

* **Chores**
  * As imagens base dos containers foram atualizadas para versões mais recentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->